### PR TITLE
Changed implicit casts (from void* to gzFile_s*) in klm

### DIFF
--- a/klm/util/file_piece.cc
+++ b/klm/util/file_piece.cc
@@ -31,7 +31,7 @@ ParseNumberException::ParseNumberException(StringPiece value) throw() {
 GZException::GZException(void *file) {
 #ifdef HAVE_ZLIB
   int num;
-  *this << gzerror(file, &num) << " from zlib";
+  *this << gzerror((gzFile_s*)file, &num) << " from zlib";
 #endif // HAVE_ZLIB
 }
 
@@ -56,7 +56,7 @@ FilePiece::~FilePiece() {
     // zlib took ownership
     file_.release();
     int ret;
-    if (Z_OK != (ret = gzclose(gz_file_))) {
+    if (Z_OK != (ret = gzclose((gzFile_s*)gz_file_))) {
       std::cerr << "could not close file " << file_name_ << " using zlib" << std::endl;
       abort();
     }
@@ -296,7 +296,7 @@ void FilePiece::ReadShift() {
 
   ssize_t read_return;
 #ifdef HAVE_ZLIB
-  read_return = gzread(gz_file_, static_cast<char*>(data_.get()) + already_read, default_map_size_ - already_read);
+  read_return = gzread((gzFile_s*)gz_file_, static_cast<char*>(data_.get()) + already_read, default_map_size_ - already_read);
   if (read_return == -1) throw GZException(gz_file_);
   if (total_size_ != kBadSize) {
     // Just get the position, don't actually seek.  Apparently this is how you do it. . . 


### PR DESCRIPTION
With the current version I get a compile error in klm/util/file_piece.cc

file_piece.cc: In constructor ‘util::GZException::GZException(void_)’:
file_piece.cc:34: error: invalid conversion from ‘void_’ to ‘gzFile_s_’
file_piece.cc:34: error:   initializing argument 1 of ‘const char_ gzerror(gzFile_s_, int_)’
file_piece.cc: In destructor ‘util::FilePiece::~FilePiece()’:
file_piece.cc:59: error: invalid conversion from ‘void_’ to ‘gzFile_s_’
file_piece.cc:59: error:   initializing argument 1 of ‘int gzclose(gzFile_s_)’
file_piece.cc: In member function ‘void util::FilePiece::ReadShift()’:
file_piece.cc:299: error: invalid conversion from ‘void_’ to ‘gzFile_s_’
file_piece.cc:299: error:   initializing argument 1 of ‘int gzread(gzFile_s_, void*, unsigned int)’

The compiler (g++ (Debian 4.4.5-8) 4.4.5) is getting mad at me for doing an implicit cast, so this pull request fixes this by adding explicit casts. The strange thing is, the same compiler works fine when compiling the kenlm I pulled directly from git, and I wasn't immediately able to debug why... Feel free to deny the request and fix it upstream, whatever works best.
