### PR TITLE
forced alignment for fast_align

### DIFF
--- a/word-aligner/ttables.cc
+++ b/word-aligner/ttables.cc
@@ -21,6 +21,20 @@ void TTable::DeserializeProbsFromText(std::istream* in) {
   cerr << "Loaded " << c << " translation parameters.\n";
 }
 
+void TTable::DeserializeLogProbsFromText(std::istream* in) {
+  int c = 0;
+  while(*in) {
+    string e;
+    string f;
+    double p;
+    (*in) >> e >> f >> p;
+    if (e.empty()) break;
+    ++c;
+    ttable[TD::Convert(e)][TD::Convert(f)] = exp(p);
+  }
+  cerr << "Loaded " << c << " translation parameters.\n";
+}
+
 void TTable::SerializeHelper(string* out, const Word2Word2Double& o) {
   assert(!"not implemented");
 }

--- a/word-aligner/ttables.h
+++ b/word-aligner/ttables.h
@@ -86,6 +86,7 @@ class TTable {
     }
   }
   void DeserializeProbsFromText(std::istream* in);
+  void DeserializeLogProbsFromText(std::istream* in);
   void SerializeCounts(std::string* out) const { SerializeHelper(out, counts); }
   void DeserializeCounts(const std::string& in) { DeserializeHelper(in, &counts); }
   void SerializeProbs(std::string* out) const { SerializeHelper(out, ttable); }


### PR DESCRIPTION
Made minor changes to fast_align code to support forced alignment of new data using the parameters estimated during EM on the training set.

fast_align.cc
- changed output_parameters flag to write params to file
- added force_align flag to load written params from training, skip EM (0 iterations) and align input as the testset
- added mean_srclen_multiplier flag to set mean source length multiplier manually when force aligning input.

ttables.cc/h
- added new function DeserializeLogProbsFromText() to load params from output_parameters file

Example Usage:
(1) Training
./fast_align -i training -d -o -v -p training.params > training.align 2> training.log
(get final_tension and source length multiplier from training.log)
(2) Forced Alignment
./fast_align -i test -d -T <diagonal tension from training> -m <mean_srclen_multiplier from training> -f training.params > test.align
