### PR TITLE
mira breaks on noninteractive machines when matplotlib is installed, com...

### DIFF
--- a/training/mira/mira.py
+++ b/training/mira/mira.py
@@ -12,6 +12,8 @@ except ImportError:
   sys.exit(1)
 have_mpl = True
 try: 
+  import matplotlib
+  matplotlib.use('Agg')
   import matplotlib.pyplot as plt
 except ImportError:
   have_mpl = False


### PR DESCRIPTION
...plaining that $DISPLAY environment variable is not set. fix it as described at http://matplotlib.org/faq/howto_faq.html
