### PR TITLE
Update run-system-tests.pl

### DIFF
--- a/tests/run-system-tests.pl
+++ b/tests/run-system-tests.pl
@@ -8,7 +8,7 @@ my $TEMP_DIR = tempdir( CLEANUP => 1 );
 
 #my $cwd = cwd();
 #die "Sanity failed: $cwd" unless -d $cwd;
-my $DECODER = "$script_dir/../decoder/cdec";
+my $DECODER = "$script_dir/../build/decoder/cdec";
 my $FILTER = "$script_dir/tools/filter-stderr.pl";
 my $COMPARE_STATS = "$script_dir/tools/compare-statistics.pl";
 my $XDIFF = "$script_dir/tools/flex-diff.pl";


### PR DESCRIPTION
Line 6 doesn't work, but there are two possible reasons (and possible fixes). Either
A) the test should be looking for the build decoder in $cdec/build/decoder/cdec instead of in $cdec/decoder/cdec.
or
B) the "make -j4" command should be creating a decoder executable at $cdec/decoder/cdec , but isn't.

I assumed (A), because it's simpler.